### PR TITLE
to avoid committing .DS_Store files in mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
I created a .gtiignore file, so when we commit, we can ignore certain Operating System specific files. These are the files that are not created by our team developers. Rather, these files are created by the Operating System for its internal use. So we do not need to commit these files into our repository.
One example of this file is the .DS_Store file that is created by Mac when the repository folder is opened in the File Viewer. 